### PR TITLE
follow bip174 spec updates: an input can have both nonWitnessUtxo and witnessUtxo

### DIFF
--- a/src/lib/parser/fromBuffer.js
+++ b/src/lib/parser/fromBuffer.js
@@ -182,12 +182,9 @@ function psbtFromKeyVals(
             keyVal.key,
             typeFields_1.InputTypes.NON_WITNESS_UTXO,
           );
-          if (
-            input.nonWitnessUtxo !== undefined ||
-            input.witnessUtxo !== undefined
-          ) {
+          if (input.nonWitnessUtxo !== undefined) {
             throw new Error(
-              'Format Error: Input has multiple [NON_]WITNESS_UTXO',
+              'Format Error: Input has multiple NON_WITNESS_UTXO',
             );
           }
           input.nonWitnessUtxo = convert.inputs.nonWitnessUtxo.decode(keyVal);
@@ -198,13 +195,8 @@ function psbtFromKeyVals(
             keyVal.key,
             typeFields_1.InputTypes.WITNESS_UTXO,
           );
-          if (
-            input.nonWitnessUtxo !== undefined ||
-            input.witnessUtxo !== undefined
-          ) {
-            throw new Error(
-              'Format Error: Input has multiple [NON_]WITNESS_UTXO',
-            );
+          if (input.witnessUtxo !== undefined) {
+            throw new Error('Format Error: Input has multiple WITNESS_UTXO');
           }
           input.witnessUtxo = convert.inputs.witnessUtxo.decode(keyVal);
           break;

--- a/src/tests/fixtures/keyValsToPsbt.js
+++ b/src/tests/fixtures/keyValsToPsbt.js
@@ -70,10 +70,8 @@ exports.fixtures = [
       inputKeyVals: [
         [
           {
-            key: b('01'),
-            value: b(
-              '70aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d',
-            ),
+            key: b('00'),
+            value: b('03'),
           },
           {
             key: b('00'),
@@ -83,7 +81,7 @@ exports.fixtures = [
       ],
       outputKeyVals: [],
     },
-    exception: 'Format Error: Input has multiple \\[NON_\\]WITNESS_UTXO',
+    exception: 'Format Error: Input has multiple NON_WITNESS_UTXO',
   },
   {
     data: {
@@ -91,18 +89,22 @@ exports.fixtures = [
       inputKeyVals: [
         [
           {
-            key: b('00'),
-            value: b('04'),
+            key: b('01'),
+            value: b(
+              '70aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d',
+            ),
           },
           {
             key: b('01'),
-            value: b('05'),
+            value: b(
+              '70aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d',
+            ),
           },
         ],
       ],
       outputKeyVals: [],
     },
-    exception: 'Format Error: Input has multiple \\[NON_\\]WITNESS_UTXO',
+    exception: 'Format Error: Input has multiple WITNESS_UTXO ',
   },
   {
     data: {

--- a/src/tests/keyValsToPsbt.js
+++ b/src/tests/keyValsToPsbt.js
@@ -8,9 +8,13 @@ const txTools_1 = require('./utils/txTools');
 for (const f of keyValsToPsbt_1.fixtures) {
   if (f.exception) {
     tape('From keyVals should throw:', t => {
-      t.throws(() => {
-        fromBuffer_1.psbtFromKeyVals(txTools_1.getDefaultTx(), f.data);
-      }, new RegExp(f.exception));
+      t.throws(
+        () => {
+          fromBuffer_1.psbtFromKeyVals(txTools_1.getDefaultTx(), f.data);
+        },
+        Error,
+        f.exception,
+      );
       t.end();
     });
   } else {

--- a/ts_src/lib/parser/fromBuffer.ts
+++ b/ts_src/lib/parser/fromBuffer.ts
@@ -213,25 +213,17 @@ export function psbtFromKeyVals(
       switch (keyVal.key[0]) {
         case InputTypes.NON_WITNESS_UTXO:
           checkKeyBuffer('input', keyVal.key, InputTypes.NON_WITNESS_UTXO);
-          if (
-            input.nonWitnessUtxo !== undefined ||
-            input.witnessUtxo !== undefined
-          ) {
+          if (input.nonWitnessUtxo !== undefined) {
             throw new Error(
-              'Format Error: Input has multiple [NON_]WITNESS_UTXO',
+              'Format Error: Input has multiple NON_WITNESS_UTXO',
             );
           }
           input.nonWitnessUtxo = convert.inputs.nonWitnessUtxo.decode(keyVal);
           break;
         case InputTypes.WITNESS_UTXO:
           checkKeyBuffer('input', keyVal.key, InputTypes.WITNESS_UTXO);
-          if (
-            input.nonWitnessUtxo !== undefined ||
-            input.witnessUtxo !== undefined
-          ) {
-            throw new Error(
-              'Format Error: Input has multiple [NON_]WITNESS_UTXO',
-            );
+          if (input.witnessUtxo !== undefined) {
+            throw new Error('Format Error: Input has multiple WITNESS_UTXO');
           }
           input.witnessUtxo = convert.inputs.witnessUtxo.decode(keyVal);
           break;

--- a/ts_src/lib/parser/toBuffer.ts
+++ b/ts_src/lib/parser/toBuffer.ts
@@ -39,29 +39,26 @@ function keyValsFromMap(
 ): KeyValue[] {
   const keyHexSet: Set<string> = new Set();
 
-  const keyVals = Object.entries(keyValMap).reduce(
-    (result, [key, value]) => {
-      if (key === 'unknownKeyVals') return result;
-      // We are checking for undefined anyways. So ignore TS error
-      // @ts-ignore
-      const converter = converterFactory[key];
-      if (converter === undefined) return result;
+  const keyVals = Object.entries(keyValMap).reduce((result, [key, value]) => {
+    if (key === 'unknownKeyVals') return result;
+    // We are checking for undefined anyways. So ignore TS error
+    // @ts-ignore
+    const converter = converterFactory[key];
+    if (converter === undefined) return result;
 
-      const encodedKeyVals = (Array.isArray(value) ? value : [value]).map(
-        converter.encode,
-      ) as KeyValue[];
+    const encodedKeyVals = (Array.isArray(value) ? value : [value]).map(
+      converter.encode,
+    ) as KeyValue[];
 
-      const keyHexes = encodedKeyVals.map(kv => kv.key.toString('hex'));
-      keyHexes.forEach(hex => {
-        if (keyHexSet.has(hex))
-          throw new Error('Serialize Error: Duplicate key: ' + hex);
-        keyHexSet.add(hex);
-      });
+    const keyHexes = encodedKeyVals.map(kv => kv.key.toString('hex'));
+    keyHexes.forEach(hex => {
+      if (keyHexSet.has(hex))
+        throw new Error('Serialize Error: Duplicate key: ' + hex);
+      keyHexSet.add(hex);
+    });
 
-      return result.concat(encodedKeyVals);
-    },
-    [] as KeyValue[],
-  );
+    return result.concat(encodedKeyVals);
+  }, [] as KeyValue[]);
 
   // Get other keyVals that have not yet been gotten
   const otherKeyVals = keyValMap.unknownKeyVals

--- a/ts_src/tests/fixtures/keyValsToPsbt.ts
+++ b/ts_src/tests/fixtures/keyValsToPsbt.ts
@@ -69,10 +69,8 @@ export const fixtures = [
       inputKeyVals: [
         [
           {
-            key: b('01'),
-            value: b(
-              '70aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d',
-            ),
+            key: b('00'),
+            value: b('03'),
           },
           {
             key: b('00'),
@@ -82,7 +80,7 @@ export const fixtures = [
       ],
       outputKeyVals: [],
     },
-    exception: 'Format Error: Input has multiple \\[NON_\\]WITNESS_UTXO',
+    exception: 'Format Error: Input has multiple NON_WITNESS_UTXO',
   },
   {
     data: {
@@ -90,18 +88,22 @@ export const fixtures = [
       inputKeyVals: [
         [
           {
-            key: b('00'),
-            value: b('04'),
+            key: b('01'),
+            value: b(
+              '70aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d',
+            ),
           },
           {
             key: b('01'),
-            value: b('05'),
+            value: b(
+              '70aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d',
+            ),
           },
         ],
       ],
       outputKeyVals: [],
     },
-    exception: 'Format Error: Input has multiple \\[NON_\\]WITNESS_UTXO',
+    exception: 'Format Error: Input has multiple WITNESS_UTXO ',
   },
   {
     data: {

--- a/ts_src/tests/keyValsToPsbt.ts
+++ b/ts_src/tests/keyValsToPsbt.ts
@@ -7,9 +7,13 @@ import { getDefaultTx, transactionFromBuffer } from './utils/txTools';
 for (const f of fixtures) {
   if (f.exception) {
     tape('From keyVals should throw:', t => {
-      t.throws(() => {
-        psbtFromKeyVals(getDefaultTx(), f.data);
-      }, new RegExp(f.exception));
+      t.throws(
+        () => {
+          psbtFromKeyVals(getDefaultTx(), f.data);
+        },
+        Error,
+        f.exception,
+      );
       t.end();
     });
   } else {


### PR DESCRIPTION
As per https://github.com/bitcoin/bips/commit/5ac2cb5b93bf2ac1f1dac7337d93176a5edadd97 and https://github.com/bitcoin-core/HWI/commit/65c6de6b8a625eb272d1c0802473095093164821#diff-0d4ba12f98ef1621d8f2beed67a9ebd7, now PSBT inputs can have both nonWitnessUTXO and witnessUTXO.