### PR TITLE
Fix path regex in globalXpub validation to allow a path of just 'm'

### DIFF
--- a/src/lib/converter/global/globalXpub.js
+++ b/src/lib/converter/global/globalXpub.js
@@ -68,7 +68,7 @@ function check(data) {
     Buffer.isBuffer(mfp) &&
     mfp.length === 4 &&
     typeof p === 'string' &&
-    !!p.match(/^m(\/\d+'?)+$/)
+    !!p.match(/^m(\/\d+'?)*$/)
   );
 }
 exports.check = check;

--- a/src/tests/validation.js
+++ b/src/tests/validation.js
@@ -103,5 +103,14 @@ tape('should not pass isPartialSig with invalid DER signature', t => {
   t.throws(() => {
     combiner_1.combine([psbt1, psbt2]);
   }, new RegExp('Combine: KeyValue Map keys should be unique'));
+  t.ok(
+    converter_1.globals.globalXpub.check({
+      masterFingerprint: b('3442193e'),
+      extendedPubkey: b(
+        '0488b21e000000000000000000873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d5080339a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c2',
+      ),
+      path: 'm',
+    }),
+  );
   t.end();
 });

--- a/src/tests/validation.js
+++ b/src/tests/validation.js
@@ -107,6 +107,7 @@ tape('should not pass isPartialSig with invalid DER signature', t => {
     converter_1.globals.globalXpub.check({
       masterFingerprint: b('3442193e'),
       extendedPubkey: b(
+        // tslint:disable-next-line:max-line-length
         '0488b21e000000000000000000873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d5080339a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c2',
       ),
       path: 'm',

--- a/ts_src/lib/converter/global/globalXpub.ts
+++ b/ts_src/lib/converter/global/globalXpub.ts
@@ -73,7 +73,7 @@ export function check(data: any): data is GlobalXpub {
     Buffer.isBuffer(mfp) &&
     mfp.length === 4 &&
     typeof p === 'string' &&
-    !!p.match(/^m(\/\d+'?)+$/)
+    !!p.match(/^m(\/\d+'?)*$/)
   );
 }
 

--- a/ts_src/tests/validation.ts
+++ b/ts_src/tests/validation.ts
@@ -1,6 +1,9 @@
 import * as tape from 'tape';
 import { combine } from '../lib/combiner';
-import { globals as convertGlobal, inputs as convertInputs } from '../lib/converter';
+import {
+  globals as convertGlobal,
+  inputs as convertInputs,
+} from '../lib/converter';
 import { getDefaultTx } from './utils/txTools';
 
 const b = (hex: string): Buffer => Buffer.from(hex, 'hex');
@@ -110,11 +113,16 @@ tape('should not pass isPartialSig with invalid DER signature', t => {
     combine([psbt1, psbt2]);
   }, new RegExp('Combine: KeyValue Map keys should be unique'));
 
-  t.ok(convertGlobal.globalXpub.check({
-    masterFingerprint: b('3442193e'),
-    extendedPubkey: b('0488b21e000000000000000000873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d5080339a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c2'),
-    path: 'm',
-  }));
+  t.ok(
+    convertGlobal.globalXpub.check({
+      masterFingerprint: b('3442193e'),
+      extendedPubkey: b(
+        // tslint:disable-next-line:max-line-length
+        '0488b21e000000000000000000873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d5080339a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c2',
+      ),
+      path: 'm',
+    }),
+  );
 
   t.end();
 });

--- a/ts_src/tests/validation.ts
+++ b/ts_src/tests/validation.ts
@@ -1,6 +1,6 @@
 import * as tape from 'tape';
 import { combine } from '../lib/combiner';
-import { inputs as convertInputs } from '../lib/converter';
+import { globals as convertGlobal, inputs as convertInputs } from '../lib/converter';
 import { getDefaultTx } from './utils/txTools';
 
 const b = (hex: string): Buffer => Buffer.from(hex, 'hex');
@@ -109,6 +109,12 @@ tape('should not pass isPartialSig with invalid DER signature', t => {
   t.throws(() => {
     combine([psbt1, psbt2]);
   }, new RegExp('Combine: KeyValue Map keys should be unique'));
+
+  t.ok(convertGlobal.globalXpub.check({
+    masterFingerprint: b('3442193e'),
+    extendedPubkey: b('0488b21e000000000000000000873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d5080339a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c2'),
+    path: 'm',
+  }));
 
   t.end();
 });


### PR DESCRIPTION
Update globalXpub path checking regex to use * instead of + for digit group so a path of "m" will validate.