### PR TITLE
Fix PSBT output's unknownKeyVals

### DIFF
--- a/src/lib/psbt.js
+++ b/src/lib/psbt.js
@@ -110,7 +110,7 @@ class Psbt {
       throw new Error('unknownKeyVals must be an Array');
     }
     addKeyVals.forEach(keyVal =>
-      this.addUnknownKeyValToInput(outputIndex, keyVal),
+      this.addUnknownKeyValToOutput(outputIndex, keyVal),
     );
     utils_1.addOutputAttributes(this.outputs, outputData);
     return this;

--- a/ts_src/lib/psbt.ts
+++ b/ts_src/lib/psbt.ts
@@ -151,7 +151,7 @@ export class Psbt {
       throw new Error('unknownKeyVals must be an Array');
     }
     addKeyVals.forEach((keyVal: KeyValue) =>
-      this.addUnknownKeyValToInput(outputIndex, keyVal),
+      this.addUnknownKeyValToOutput(outputIndex, keyVal),
     );
     addOutputAttributes(this.outputs, outputData);
     return this;


### PR DESCRIPTION
Typo fixed where adding output was placing the specified unknownKeyVals into the input of the corresponding outputIndex instead.